### PR TITLE
Send results by email

### DIFF
--- a/pdfebc_web/main/views.py
+++ b/pdfebc_web/main/views.py
@@ -110,12 +110,6 @@ def tarball_in_session_upload_dir(session_id):
 def construct_blueprint(celery):
     main = Blueprint('main', __name__)
 
-    @celery.task
-    def stupid_background_task():
-        for _ in range(10):
-            print('BACKGROUND TASK')
-            time.sleep(2)
-
     @main.route('/', methods=['GET', 'POST'])
     def index():
         """View for the index page."""
@@ -144,12 +138,6 @@ def construct_blueprint(celery):
                                    for file in os.listdir(session_upload_dir_path)
                                    if file.endswith('.pdf')],
                                test_form=test_form)
-
-    @main.route('/stupid')
-    def stupid():
-        stupid_background_task.delay()
-        return redirect(url_for('main.index'))
-
 
     @main.route('/about')
     def about():

--- a/pdfebc_web/main/views.py
+++ b/pdfebc_web/main/views.py
@@ -13,7 +13,7 @@ import shutil
 import tempfile
 import uuid
 import tarfile
-from pdfebc_core import email_utils, compress
+from pdfebc_core import email_utils, compress, config_utils
 from flask import render_template, send_file, session, flash, Blueprint, redirect, url_for
 from werkzeug import secure_filename
 from .forms import FileUploadForm, CompressFilesForm
@@ -21,7 +21,7 @@ from .forms import FileUploadForm, CompressFilesForm
 PDFEBC_CORE_GITHUB = 'https://github.com/slarse/pdfebc-core'
 PDFEBC_WEB_GITHUB = 'https://github.com/slarse/pdfebc-web'
 
-FILE_CACHE = os.path.join(tempfile.gettempdir(), 'pdfebc-web')
+FILE_CACHE = os.path.join(os.path.dirname(config_utils.CONFIG_PATH), 'pdfebc-web')
 os.makedirs(FILE_CACHE, exist_ok=True)
 
 SESSION_ID_KEY = 'session_id'
@@ -121,7 +121,7 @@ def construct_blueprint(celery):
         """
         session_upload_dir = get_session_upload_dir_path(session_id)
         tar = compress_uploaded_files(session_upload_dir)
-        email_utils.send_files_preconf(tar)
+        email_utils.send_files_preconf([tar])
 
     @main.route('/', methods=['GET', 'POST'])
     def index():

--- a/pdfebc_web/templates/index.html
+++ b/pdfebc_web/templates/index.html
@@ -16,6 +16,6 @@
         </ul>
     </div>
     {% endif %}
-    {{ wtf.quick_form(test_form) }}
+    {{ wtf.quick_form(compress_form) }}
 </div>
 {% endblock %}


### PR DESCRIPTION
Send compressed files by email as separately attached PDF's.

Actual work is done by a Celery worker instead of by the interpreter, so that the application does not freeze for everyone when someone is compressing files.